### PR TITLE
Switch to the text/rust MIME type introduced into shared-mime-info.

### DIFF
--- a/share/gtksourceview-3.0/language-specs/rust.lang
+++ b/share/gtksourceview-3.0/language-specs/rust.lang
@@ -4,7 +4,7 @@
 
 <language id="rust" _name="Rust" version="2.0" _section="Sources">
   <metadata>
-    <property name="mimetypes">text/x-rust</property>
+    <property name="mimetypes">text/rust</property>
     <property name="globs">*.rs</property>
     <property name="line-comment-start">//</property>
     <property name="block-comment-start">/*</property>

--- a/share/mime/packages/rust.xml
+++ b/share/mime/packages/rust.xml
@@ -1,6 +1,0 @@
-<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
-  <mime-type type="text/x-rust">
-    <comment>Rust Source</comment>
-    <glob pattern="*.rs"/>
-  </mime-type>
-</mime-info>


### PR DESCRIPTION
Cf. https://bugs.freedesktop.org/show_bug.cgi?id=90487

Drops the text/x-rust MIME type file from the repo.

Note a shared-mime-info release with the new type has yet to happen.
